### PR TITLE
Use public github shorthand for deploying from Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.4'
-gem 'bundler-audit', git: 'git@github.com:ombulabs/bundler-audit.git'
+gem 'bundler-audit', github: 'ombulabs/bundler-audit'
 # Use sqlite3 as the database for Active Record
 # gem 'sqlite3'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:ombulabs/bundler-audit.git
+  remote: https://github.com/ombulabs/bundler-audit.git
   revision: b84d88f76c4d656421c1d810c9760b0fdea5d13a
   specs:
     bundler-audit (0.6.0)


### PR DESCRIPTION
Uses `github` instead of `git` so that Heroku can clone the public repository. It's currently failing to clone it trying to use SSH. 