### PR TITLE
Restart web dyno every x hours via Heroku API to force update bundler-audit db

### DIFF
--- a/heroku_restart.sh
+++ b/heroku_restart.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+curl -X DELETE "https://api.heroku.com/apps/bundler-audit-production/dynos" \
+  --user "${HEROKU_CLI_USER}:${HEROKU_CLI_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/vnd.heroku+json; version=3"


### PR DESCRIPTION
Because of Heroku's ephemeral file system, we can't use a Rake task to update files on the dyno running the website, since the Rake task will run in its own file system and update those files, not the ones for the website.

By restarting every x hours, we make sure that the database is updated every x hours. One of the initializers in the app runs the `Bundler::Audit::Database.update!` method, which is enough to update the database (fetches from git), so by restarting the app:

```
2018-07-10T15:39:23.350707+00:00 heroku[web.1]: Restarting
2018-07-10T15:39:23.351148+00:00 heroku[web.1]: State changed from up to starting
2018-07-10T15:39:24.088938+00:00 heroku[web.1]: Stopping all processes with SIGTERM
2018-07-10T15:39:24.102015+00:00 app[web.1]: - Gracefully stopping, waiting for requests to finish
2018-07-10T15:39:24.103275+00:00 app[web.1]: === puma shutdown: 2018-07-10 15:39:24 +0000 ===
2018-07-10T15:39:24.103281+00:00 app[web.1]: - Goodbye!
2018-07-10T15:39:24.103379+00:00 app[web.1]: Exiting
2018-07-10T15:39:24.264507+00:00 heroku[web.1]: Process exited with status 143
2018-07-10T15:39:26.287556+00:00 heroku[web.1]: Starting process with command `bin/rails server -p 41544 -e production`
2018-07-10T15:39:30.450997+00:00 app[web.1]: => Booting Puma
2018-07-10T15:39:30.451037+00:00 app[web.1]: => Rails 5.1.4 application starting in production
2018-07-10T15:39:30.451039+00:00 app[web.1]: => Run `rails server -h` for more startup options
2018-07-10T15:39:30.455205+00:00 app[web.1]: Cloning into '/app/.local/share/ruby-advisory-db'...
2018-07-10T15:39:31.701419+00:00 app[web.1]: Puma starting in single mode...
2018-07-10T15:39:31.701447+00:00 app[web.1]: * Version 3.11.2 (ruby 2.4.4-p296), codename: Love Song
2018-07-10T15:39:31.701450+00:00 app[web.1]: * Min threads: 5, max threads: 5
2018-07-10T15:39:31.701452+00:00 app[web.1]: * Environment: production
2018-07-10T15:39:31.701540+00:00 app[web.1]: * Listening on tcp://0.0.0.0:41544
2018-07-10T15:39:31.702040+00:00 app[web.1]: Use Ctrl-C to stop
2018-07-10T15:39:32.160934+00:00 heroku[web.1]: State changed from starting to up
```

You can see in the log that it clones a fresh copy from the `ruby-advisory-db` repository. Heroku already restarts dynos every 24 hours, so it's always been updated, but this makes sure that it's updated more often than that. 

After deploying this PR, we need to update the Heroku scheduler via the dashboard as well. 

Please check it out, thanks!