### PR TITLE
Updates collapse issue for pdf. 

### DIFF
--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -98,8 +98,13 @@ body{
       &.warnings-content{
         border-color: $yellow;
       }
-      &.advisories-content{
-        border-color: $red;
+      &.advisories-content {
+        .advisory-description {
+          &.collapse{
+            display: block;
+            height: auto;
+          }
+        }
       }
 
       .advisory-gem{
@@ -139,11 +144,6 @@ body{
         display: none;
       }
     }
-  }
-
-  .collapse{
-    display: block;
-    word-wrap: break-word;
   }
 
   #bottom-bar{


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171541988

Now the reports will again show the extended version and not cut off. 
@nykka and I discovered that this had happened since the fastruby-styleguide had been added. She helped me to change the `collapse` to be more specific so that it will override the other `collapse` rules.

[vulnerabilities_list_expanded.pdf](https://github.com/ombulabs/audit/files/4269274/vulnerabilities_list_expanded.pdf)
