### PR TITLE
[#172294837] Images missing alt tag

### DIFF
--- a/app/views/gemfiles/_vulnerabilities_list.html.erb
+++ b/app/views/gemfiles/_vulnerabilities_list.html.erb
@@ -21,7 +21,7 @@
     </div>
   </div>
   <div class="section__bg section__bg--left">
-    <span class=""><%= image_tag "trails-results.svg" %></span>
+    <span class=""><%= image_tag "trails-results.svg", alt: "" %></span>
   </div>
 </section>
 <section class="section section-results">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,21 +3,21 @@
 <section class="section section__full section-bottom">
   <div class="top-top">
     <a class="scrollto" href="#top">
-      <%= image_tag "circle-black-lg.svg" %>
+      <%= image_tag "circle-black-lg.svg", alt: "" %>
     </a>
   </div>
   <div class="section__bg section-bottom__bg section__bg--left">
-    <span  class="section__bg--lg"><%= image_tag "bg-branch-contactus--lg.svg" %></span>
-    <span  class="section__bg--md"><%= image_tag "bg-branch-contactus--lg.svg" %></span>
+    <span  class="section__bg--lg"><%= image_tag "bg-branch-contactus--lg.svg", alt: "" %></span>
+    <span  class="section__bg--md"><%= image_tag "bg-branch-contactus--lg.svg", alt: "" %></span>
   </div>
   <div class="section__bg section-bottom__bg section__bg--right">
-    <span  class="section__bg--lg"><%= image_tag "bg-branch-footer2--lg.svg" %></span>
-    <span  class="section__bg--md"><%= image_tag "bg-branch-footer2--lg.svg" %></span>
+    <span  class="section__bg--lg"><%= image_tag "bg-branch-footer2--lg.svg", alt: "" %></span>
+    <span  class="section__bg--md"><%= image_tag "bg-branch-footer2--lg.svg", alt: "" %></span>
   </div>
   <div class="section__bg section-bottom__bg section__bg--right section__bg--bottomright">
-    <span  class="section__bg--lg"><%= image_tag "bg-branch-footer--lg.svg" %></span>
-    <span  class="section__bg--md"><%= image_tag "bg-branch-footer--lg.svg" %></span>
-    <span  class="section__bg--sm"><%= image_tag "bg-branch-footer--lg.svg" %></span>
-    <span  class="section__bg--xs"><%= image_tag "bg-branch-footer--lg.svg" %></span>
+    <span  class="section__bg--lg"><%= image_tag "bg-branch-footer--lg.svg", alt: "" %></span>
+    <span  class="section__bg--md"><%= image_tag "bg-branch-footer--lg.svg", alt: "" %></span>
+    <span  class="section__bg--sm"><%= image_tag "bg-branch-footer--lg.svg", alt: "" %></span>
+    <span  class="section__bg--xs"><%= image_tag "bg-branch-footer--lg.svg", alt: "" %></span>
   </div>
 </section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
           <div class="navbar-brand">
             <div class="col-1 navbar-brand__logo">
               <a href="/">
-                <%= image_tag "fastruby-logo.svg", alt: "FastRuby.io" %>
+                <%= image_tag "fastruby-logo.svg", alt: "FastRuby.io Logo" %>
                 </a>
             </div>
             <div class="col-11 navbar-brand__name">

--- a/app/views/shared/_pdf-header.html.erb
+++ b/app/views/shared/_pdf-header.html.erb
@@ -4,7 +4,7 @@
     <div class="navbar-brand">
       <div class="col-1 navbar-brand__logo">
         <a href="https://audit.fastruby.io/">
-          <%= wicked_pdf_image_tag 'fastruby-logo.svg' %>
+          <%= wicked_pdf_image_tag 'fastruby-logo.svg', alt: "FastRuby.io Logo" %>
         </a>
       </div>
       <div class="col-11 navbar-brand__name">


### PR DESCRIPTION
**What is this PR:**

- [ ] Bug fix
- [ ] Feature
- [x] Chore

**Description:**

This PR adds missing `alt=""` tags to `<img>` elements.

**Related story:**

https://www.pivotaltracker.com/story/show/172294837

**Related links (if applicable):**

Semrush audit https://www.semrush.com/siteaudit/campaign/3544005/review/#issue/detail/110/sorting/index_asc/page/1/filter/%2B|source_url|Co|https%3A%2F%2Fwww.fastruby.io

W3 documentation regarding decorative images
https://www.w3.org/WAI/tutorials/images/decorative/

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**

Tested in all browsers.

**What browsers did you test it on (if applicable)?**

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari
