### PR TITLE
[#172295082] Audit Tool site is missing meta description 

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,9 +3,12 @@
   <head>
     <% if controller_name == 'gemfiles' %>
       <title>Audit Tool - Report #<%= @alpha_id %></title>
+      <meta name="description" content="Report #<%= @alpha_id %> - <%= @vulnerabilities_count %> Vulnerabilities found on your file"/>
     <% else %>
-      <title>Audit Tool - Upload your Gemfile.lock to find vulnerabilities in your application</title>
+      <title>Audit Tool</title>
+      <meta name="description" content="Upload your Gemfile.lock to find vulnerabilities in your application"/>
     <% end %>
+
 
     <%= csrf_meta_tags %>
 


### PR DESCRIPTION
**What is this PR:**

- [ ] Bug fix
- [ ] Feature
- [x] Chore

**Description:**

This PR adds a description meta tag to `<head>`

**Related story:**

https://www.pivotaltracker.com/story/show/172295082

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**

Manually tested in browsers.

**What browsers did you test it on (if applicable)?**

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari