### PR TITLE
[#172294973] Pages have no hreflang and lang attributes

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <% if controller_name == 'gemfiles' %>
       <title>Audit Tool - Report #<%= @alpha_id %></title>


### PR DESCRIPTION
**What is this PR:**

- [ ] Bug fix
- [ ] Feature
- [x] Chore

**Description:**

This PR adds `lang` attribute to `html` tag

**Related story:**

https://www.pivotaltracker.com/story/show/172294973

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**What manual tests have been run?**

Manually tested in all browsers.

**What browsers did you test it on (if applicable)?**

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari
