### PR TITLE
Adds an updated version of mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.4)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.3.0)
     minitest (5.14.0)


### PR DESCRIPTION
**What is this PR:**

- [X] Bug fix
- [ ] Feature
- [ ] Chore

**Description:**

I am adding this to fix the problems with running `bundle install` and `./bin/setup` that I had when I tried to set up the project. Some of the gems we are using are affected by the issue talked about here: https://github.com/rails/rails/issues/41750 
Namely, `mimemagic 0.3.4` was removed from Rubygems due to licensing issues. I decided to update `mimemagic` to 0.3.10 to fix the issue. 

**Related story:**

https://www.pivotaltracker.com/story/show/178128813 (Ultimately I plan to deploy on Heroku and upgrade the deployment's stack)

**How has this been tested?**

- [ ] Automated tests
- [X] Manual tests

**What manual tests have been run?**

After I updated the `Gemfile.lock` I was able to run `rails server` and start the project.

**What browsers did you test it on (if applicable)?**

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

**What devices did you test it on (if applicable)?**

- [X] Laptop / PC
- [ ] Tablet
- [ ] Mobile
