### PR TITLE
Set GOOGLE_ANALYTICS_ID as an env var

### DIFF
--- a/app/views/home/_google_analytics.html.erb
+++ b/app/views/home/_google_analytics.html.erb
@@ -1,11 +1,11 @@
 <% if Rails.env.production? %>
   <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-100557009-1"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GOOGLE_ANALYTICS_ID'] %>"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', 'UA-100557009-1');
+    gtag('config', "<%= ENV["GOOGLE_ANALYTICS_ID"] %>");
   </script>
 <% end %>


### PR DESCRIPTION
**Description:**

This PR moves the Google Analytic ID to an env var so it's not harcorded in the code.

Motivation: https://ombulabs.atlassian.net/browse/OSS-15

Note: The new env var (`GOOGLE_ANALYTICS_ID`) it's only necessary on production.

**How has this been tested?**

- [ ] Automated tests
- [x] Manual tests

**Before deploying**

- [x] Make sure to add the new env var to Heroku for both staging and production.
