### PR TITLE
Gzip text responses by adding Rack::Deflater middleware

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           command: |
             echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
             source $BASH_ENV
-            gem install bundler
+            gem install bundler -v "$BUNDLER_VERSION"
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - save_cache:
@@ -112,7 +112,7 @@ jobs:
           command: |
             echo 'export BUNDLER_VERSION=$(cat Gemfile.next.lock | tail -1 | tr -d " ")' >> $BASH_ENV
             source $BASH_ENV
-            gem install bundler
+            gem install bundler -v "$BUNDLER_VERSION"
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       - save_cache:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,4 +88,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Gzip text responses (HTML/CSS/JS) so pages aren't served uncompressed.
+  config.middleware.use Rack::Deflater
 end


### PR DESCRIPTION
# Description:

The app served every response uncompressed, there was no compression middleware at all. SEMrush's audit of fastruby.io flagged `audit.fastruby.io/` among 287 uncompressed pages, which one belongs here: https://audit.fastruby.io/

- Added `Rack::Deflater` to the production middleware stack so text responses (HTML/CSS/JS) go out gzipped.

# Link to Jira

[FR-741: FastRuby.io performance — 1 page served uncompressed](https://ombulabs.atlassian.net/browse/FR-741)

# QA Notes

### Locally

The app needs Ruby 2.7.5 and the older bundler. `force_ssl` is on, so pass `X-Forwarded-Proto: https`.

1. Quick check, confirm `Rack::Deflater` is in the production middleware stack:
```bash
exec rails middleware | grep Deflater
```

2. Full check, boot the server and curl the root:
```bash
exec rails server

curl -s -H "Accept-Encoding: gzip" -H "X-Forwarded-Proto: https" \
  -D - http://127.0.0.1:3000/ -o /dev/null | grep -i content-encoding
```
Expect `Content-Encoding: gzip`.

### Production
Curl the root:
```
curl -s -H "Accept-Encoding: gzip, br" -D - https://audit.fastruby.io/ -o /dev/null | grep -i content-encoding
```
Expect Content-Encoding: `gzip`.
3. Re-run the SEMrush audit to confirm audit.fastruby.io is no longer flagged as uncompressed.

