### PR TITLE
Bump Bundler to 4.0.15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,4 @@ group :development do
   gem "spring-watcher-listen", "~> 2.1.0"
 end
 
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo-data", platforms: [:windows, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,7 +458,7 @@ DEPENDENCIES
   wkhtmltopdf-binary (= 0.12.3.1)
 
 RUBY VERSION
-   ruby 3.4.9p82
+  ruby 3.4.9p82
 
 BUNDLED WITH
-   2.6.9
+  4.0.15

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -458,7 +458,7 @@ DEPENDENCIES
   wkhtmltopdf-binary (= 0.12.3.1)
 
 RUBY VERSION
-   ruby 3.4.9p82
+  ruby 3.4.9p82
 
 BUNDLED WITH
-   2.6.9
+  4.0.15


### PR DESCRIPTION
## What

Bumps **Bundler 2.6.9 → 4.0.15**. Bundler's major version tracks RubyGems, not the Ruby language — 4.0.15 requires only **Ruby ≥ 3.2.0** and **RubyGems ≥ 3.4.1**, both satisfied by the current Ruby 3.4.9 / RubyGems 3.6.9. No Ruby 4 required.

## Changes

- `BUNDLED WITH` → `4.0.15` in both `Gemfile.lock` and `Gemfile.next.lock`. Adopted by running Bundler 4 itself (`bundle _4.0.15_ install`), not just editing the pin, so any lockfile-format change is captured — here it was only the value indentation (3→2 spaces).
- `Gemfile`: replaced the deprecated `platforms: [:mingw, :mswin, :x64_mingw, :jruby]` on `tzinfo-data` with `[:windows, :jruby]`. Bundler 4 warns those individual windows platform symbols will be removed in favor of the `:windows` umbrella; this clears the warning.

## Verification (host, bundler 4.0.15, ruby 3.4.9, Postgres 16.13)

- Re-lock under Bundler 4 is deprecation-free.
- Dev and production boot clean.
- Suite green — 16 runs, 52 assertions, 0 failures, 0 errors.

CI picks up the new bundler automatically: `ruby/setup-ruby` with `bundler-cache: true` reads `BUNDLED WITH` and installs 4.0.15 to match the lock.

## Not included

"Latest Ruby" is now **4.0.4** (there is no 3.5–3.9; Ruby went 3.4 → 4.0). That's a major-version hop and unrelated to this change, so it belongs in its own PR following the full upgrade methodology (deprecation sweep, floor audit, boot smoke, suite) — not bundled here.
