### PR TITLE
Remove unused jbuilder gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ gem "uglifier", ">= 1.3.0"
 
 gem "coffee-rails", "~> 5.0"
 gem "turbolinks", "~> 5"
-gem "jbuilder", "~> 2.5"
 gem "redcarpet"
 gem "wicked_pdf", "1.4.0"
 gem "wkhtmltopdf-binary", "0.12.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,9 +194,6 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.13.0)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     jmespath (1.6.2)
     jquery-rails (4.6.1)
       rails-dom-testing (>= 1, < 3)
@@ -437,7 +434,6 @@ DEPENDENCIES
   dotenv-rails
   fastruby-styleguide!
   font-awesome-rails (>= 4.7.0.9)
-  jbuilder (~> 2.5)
   kt-paperclip (~> 8.0.0)
   listen (>= 3.5)
   minitest (< 6)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -194,9 +194,6 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.13.0)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     jmespath (1.6.2)
     jquery-rails (4.6.1)
       rails-dom-testing (>= 1, < 3)
@@ -437,7 +434,6 @@ DEPENDENCIES
   dotenv-rails
   fastruby-styleguide!
   font-awesome-rails (>= 4.7.0.9)
-  jbuilder (~> 2.5)
   kt-paperclip (~> 8.0.0)
   listen (>= 3.5)
   minitest (< 6)


### PR DESCRIPTION
## What

Removes the unused `jbuilder` gem.

## Why

`jbuilder` is dead weight in this app: it renders HTML and PDF only, with no JSON endpoints. A root-usage pass found:

- No `.jbuilder` templates anywhere
- No `json.` rendering in any view
- No `format.json` / `render json:` in any controller

Nothing in the app exercises the gem, so it is safe to drop.

## Changes

- Removed `gem "jbuilder", "~> 2.5"` from the `Gemfile`
- Updated `Gemfile.lock` and the dual-boot `Gemfile.next.lock` accordingly

## Verification

- App boots on the changed bundle
- Full test suite passes: **16 runs, 52 assertions, 0 failures, 0 errors, 0 skips**
