### PR TITLE
Remove orphaned clipboard-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,6 @@ gem "aws-sdk-s3"
 
 gem "pg", "~> 1.1"
 
-gem "clipboard-rails"
-
 group :development, :test do
   gem "capybara", "~> 3.40"
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,6 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     climate_control (1.2.0)
-    clipboard-rails (1.7.1)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -431,7 +430,6 @@ DEPENDENCIES
   aws-sdk-s3
   bundler-audit
   capybara (~> 3.40)
-  clipboard-rails
   coffee-rails (~> 5.0)
   concurrent-ruby (< 1.3.5)
   dotenv-rails

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -132,7 +132,6 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     climate_control (1.2.0)
-    clipboard-rails (1.7.1)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -431,7 +430,6 @@ DEPENDENCIES
   aws-sdk-s3
   bundler-audit
   capybara (~> 3.40)
-  clipboard-rails
   coffee-rails (~> 5.0)
   concurrent-ruby (< 1.3.5)
   dotenv-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,3 @@
 //
 //= require turbolinks
 //= require_tree .
-//= require clipboard


### PR DESCRIPTION
## What

Removes the orphaned `clipboard-rails` gem.

## Why

`clipboard-rails` was pulled into the asset bundle via `//= require clipboard` in `app/assets/javascripts/application.js`, but nothing in the app ever used it:

- No `Clipboard()` / `new Clipboard(...)` instantiation
- No `data-clipboard-*` attributes in any view
- No copy-to-clipboard wiring anywhere

It is an orphaned dependency (a dead `require` with no consumer), not a used feature.

## Changes

- Removed `gem "clipboard-rails"` from the `Gemfile`
- Removed the dead `//= require clipboard` line from the asset manifest
- Updated `Gemfile.lock` and the dual-boot `Gemfile.next.lock`

## Verification

- App boots on the changed bundle
- `assets:precompile` succeeds without the require
- Full test suite passes: **16 runs, 52 assertions, 0 failures, 0 errors, 0 skips**
