### PR TITLE
Upgrade asset pipeline to Sprockets 4 (sass-rails 5 -> 6)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem "puma", "~> 3.7"
 # version as collateral.
 gem "minitest", "< 6"
 gem "nokogiri", ">= 1.13.0"
-gem "sass-rails", "~> 5.0"
+gem "sass-rails", "~> 6.0"
 gem "font-awesome-rails", ">= 4.7.0.9"
 gem "uglifier", ">= 1.3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,14 +359,16 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     securerandom (0.4.1)
     selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -376,10 +378,10 @@ GEM
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
       spring (>= 4)
-    sprockets (3.7.5)
-      base64
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      logger
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.5.2)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
@@ -444,7 +446,7 @@ DEPENDENCIES
   redcarpet
   reek
   rubocop-rails-omakase
-  sass-rails (~> 5.0)
+  sass-rails (~> 6.0)
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.1.0)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -359,14 +359,16 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     securerandom (0.4.1)
     selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -376,10 +378,10 @@ GEM
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
       spring (>= 4)
-    sprockets (3.7.5)
-      base64
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      logger
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.5.2)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
@@ -444,7 +446,7 @@ DEPENDENCIES
   redcarpet
   reek
   rubocop-rails-omakase
-  sass-rails (~> 5.0)
+  sass-rails (~> 6.0)
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.1.0)


### PR DESCRIPTION
## What

Moves the asset pipeline onto **Sprockets 4** by upgrading `sass-rails` `~> 5.0` → `~> 6.0`.

## Why

`sass-rails 5.1.0` constrained `sprockets (>= 2.8, < 4.0)`, pinning the app to Sprockets 3.7.5. That old Sprockets version registers a CoffeeScript engine **unconditionally** and, during `assets:precompile`, requires the `coffee_script` lib — which blocks two cleanups (removing the dead `coffee-rails`, swapping `uglifier` → `terser`). Sprockets 4 dropped those built-in language engines, so this upgrade is the prerequisite that unblocks them.

## Changes

- `sass-rails` `~> 5.0` → `~> 6.0` (delegates SCSS compilation to `sassc-rails`)
- Resolves to `sprockets 4.2.2` (was 3.7.5); adds `sassc-rails 2.1.2`
- Both `Gemfile.lock` and the dual-boot `Gemfile.next.lock` updated
- Used `--conservative` so **`rack` stays at 2.2.23** rather than being dragged to 3.x as collateral — a rack major is out of scope here
- `app/assets/config/manifest.js` (required by Sprockets 4) was already present; no change needed

## Verification

- Boots on Sprockets 4.2.2
- `assets:precompile` succeeds — `application.js`, `application.css`, and `pdf.css` all compile, including the `@import "font-awesome"` and `@import "fastruby/styleguide"` paths
- Full test suite passes: **16 runs, 52 assertions, 0 failures, 0 errors, 0 skips**
- The pre-existing `sass` gem deprecation warnings are gone (sass-rails 6 uses `sassc`)

## Follow-ups this unblocks

- Remove `coffee-rails` (dead; only file is an empty scaffold stub)
- Replace `uglifier` → `terser`
