### PR TITLE
Replace uglifier with terser as the JS compressor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "minitest", "< 6"
 gem "nokogiri", ">= 1.13.0"
 gem "sass-rails", "~> 6.0"
 gem "font-awesome-rails", ">= 4.7.0.9"
-gem "uglifier", ">= 1.3.0"
+gem "terser"
 
 gem "turbolinks", "~> 5"
 gem "redcarpet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,8 @@ GEM
       sprockets (>= 3.0.0)
     terrapin (1.1.1)
       climate_control
+    terser (1.2.8)
+      execjs (>= 0.3.0, < 3)
     thor (1.5.0)
     tilt (2.8.0)
     timeout (0.6.1)
@@ -390,8 +392,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -442,9 +442,9 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.1.0)
+  terser
   turbolinks (~> 5)
   tzinfo-data
-  uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   wicked_pdf (= 1.4.0)
   wkhtmltopdf-binary (= 0.12.3.1)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -381,6 +381,8 @@ GEM
       sprockets (>= 3.0.0)
     terrapin (1.1.1)
       climate_control
+    terser (1.2.8)
+      execjs (>= 0.3.0, < 3)
     thor (1.5.0)
     tilt (2.8.0)
     timeout (0.6.1)
@@ -390,8 +392,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -442,9 +442,9 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.1.0)
+  terser
   turbolinks (~> 5)
   tzinfo-data
-  uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   wicked_pdf (= 1.4.0)
   wkhtmltopdf-binary (= 0.12.3.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,8 +20,7 @@ module VulnerableGems
 
     # This app doesn't use ActiveStorage or ActionCable (file uploads go
     # through Paperclip); stop their JS from being auto-added to the asset
-    # precompile list. Their modern ES6 syntax breaks Uglifier's ES5-only
-    # parser, which otherwise fails `assets:precompile` on unused assets.
+    # precompile list -- it's unused, so there's no point compiling it.
     config.active_storage.precompile_assets = false
     config.action_cable.precompile_assets = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,7 +17,8 @@ Rails.application.config.assets.precompile += %w(pdf.scss)
 
 # This app doesn't use ActionText (no rich_text fields); it has no
 # precompile_assets opt-out flag like ActiveStorage/ActionCable, so remove
-# its auto-added JS directly. Same ES6-vs-Uglifier problem as the other two.
+# its auto-added JS directly. Same reasoning as those two: unused JS, no
+# point precompiling it.
 # Must happen in after_initialize: ActionText's own engine initializer adds
 # these entries, and it runs after this file, re-adding them if subtracted here.
 Rails.application.config.after_initialize do


### PR DESCRIPTION
## What

Replaces `uglifier` with `terser` as the JavaScript compressor.

## Why

`uglifier` is ES5-only (it can't parse modern ES6+ syntax) and is effectively legacy. `terser` is the maintained, ES6-capable drop-in that modern Rails uses. The ES5 limitation had already forced workarounds in this app (excluding ActiveStorage/ActionCable/ActionText JS from precompile).

## Changes

- `Gemfile`: `gem "uglifier"` → `gem "terser"` (1.2.8)
- `config/environments/production.rb`: `config.assets.js_compressor = :uglifier` → `:terser`
- Refreshed two comments (`config/application.rb`, `config/initializers/assets.rb`) that blamed Uglifier's ES5 parser for the precompile exclusions. **The exclusions stay** — that JS is genuinely unused here (uploads go through Paperclip, no ActionText) — but the rationale is now simply "unused," not a compressor limitation.
- Both `Gemfile.lock` and the dual-boot `Gemfile.next.lock` updated

## Verification (local)

- Boots
- **Production** `assets:precompile` succeeds with terser minifying `application.js` (exercises the actual `js_compressor = :terser` path, not just dev compilation)
- Test suite: **16 runs, 52 assertions, 0 failures, 0 errors, 0 skips**
- `rubocop` clean (exact CI config `.rubocop_with_todo.yml`)
- `reek` clean (0 warnings)
