### PR TITLE
Upgrade puma 3.12.6 -> 8.0.2 (security: clears 7+ CVEs)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "bundler-audit"
 gem "next_rails"
 gem "ostruct"
 gem "concurrent-ruby", "< 1.3.5"
-gem "puma", "~> 3.7"
+gem "puma", "~> 8.0"
 # minitest 6.0 dropped minitest/mock.rb into a separate minitest-mock gem;
 # pinned below 6 so a transitive bump (e.g. via `bundle update rails`)
 # doesn't silently drag the test suite's own framework across a major

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,8 @@ GEM
     prettyprint (0.2.0)
     prism (1.9.0)
     public_suffix (7.0.5)
-    puma (3.12.6)
+    puma (8.0.2)
+      nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.23)
     rack-session (1.0.2)
@@ -433,7 +434,7 @@ DEPENDENCIES
   nokogiri (>= 1.13.0)
   ostruct
   pg (~> 1.1)
-  puma (~> 3.7)
+  puma (~> 8.0)
   rails (>= 8.1.0, < 8.2.0)
   redcarpet
   reek

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -252,7 +252,8 @@ GEM
     prettyprint (0.2.0)
     prism (1.9.0)
     public_suffix (7.0.5)
-    puma (3.12.6)
+    puma (8.0.2)
+      nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.23)
     rack-session (1.0.2)
@@ -433,7 +434,7 @@ DEPENDENCIES
   nokogiri (>= 1.13.0)
   ostruct
   pg (~> 1.1)
-  puma (~> 3.7)
+  puma (~> 8.0)
   rails (>= 8.1.0, < 8.2.0)
   redcarpet
   reek


### PR DESCRIPTION
## What

Security upgrade: `puma` `~> 3.7` (3.12.6) → `~> 8.0` (8.0.2).

## Why

puma was pinned at 3.12.6 — EOL (2020) and carrying a stack of advisories, including a **Critical** HTTP request-smuggling CVE plus several High/Medium ones. The `~> 3.7` pin blocked every fix, so this is the highest-priority security item in the audit.

**Why puma 8 and not 6:** puma 6.x still carries two open **High** advisories — CVE-2026-47736 / CVE-2026-47737 (PROXY Protocol v1) — whose only fix is `~> 7.2.1` / `>= 8.0.2`. Bumping to 6.x would clear the old CVEs but leave those two. puma 8.0.2 clears all of them; `bundle-audit` shows no remaining puma advisories.

## Changes

- `Gemfile`: `gem "puma", "~> 3.7"` → `"~> 8.0"` (resolves to 8.0.2)
- Both `Gemfile.lock` and the dual-boot `Gemfile.next.lock` updated
- **No config changes needed** — `config/puma.rb` uses only the standard `threads` / `port` / `environment` DSL + the `tmp_restart` plugin, all still valid in puma 8; the `Procfile`'s `-t/-p/-e` flags are unchanged
- Used `--conservative` so `rack` stays at 2.2.23 (no collateral major)

## Verification (local)

- `bundle-audit`: **no remaining puma advisories** (the whole point)
- puma 8.0.2 **boots as a server and serves HTTP 200 on `/`**
- App boots (`Rails.env`)
- Test suite: **16 runs, 52 assertions, 0 failures, 0 errors, 0 skips**
- `rubocop` clean (exact CI config), `reek` clean

## Note

Two non-puma advisories remain in the audit and are handled separately: `concurrent-ruby` (next PR — unpin `< 1.3.5`, update to `>= 1.3.7`) and `webrick` (transitive, no upstream patch yet; low exposure since puma serves in production).
