### PR TITLE
Unpin concurrent-ruby and update to 1.3.7 (security)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,11 @@ end
 gem "bundler-audit"
 gem "next_rails"
 gem "ostruct"
-gem "concurrent-ruby", "< 1.3.5"
+# `< 1.3.5` was a Rails 6.1-era compatibility guard (concurrent-ruby 1.3.5
+# dropped its `logger` dependency, breaking Rails < 7.1); obsolete on Rails
+# 8.1. Now a security floor instead: 1.3.4 carries CVE-2026-54904/5/6, fixed
+# in 1.3.7.
+gem "concurrent-ruby", ">= 1.3.7"
 gem "puma", "~> 8.0"
 # minitest 6.0 dropped minitest/mock.rb into a separate minitest-mock gem;
 # pinned below 6 so a transitive bump (e.g. via `bundle update rails`)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     climate_control (1.2.0)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.7)
     date (3.5.1)
@@ -423,7 +423,7 @@ DEPENDENCIES
   aws-sdk-s3
   bundler-audit
   capybara (~> 3.40)
-  concurrent-ruby (< 1.3.5)
+  concurrent-ruby (>= 1.3.7)
   dotenv-rails
   fastruby-styleguide!
   font-awesome-rails (>= 4.7.0.9)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -132,7 +132,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     climate_control (1.2.0)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.7)
     date (3.5.1)
@@ -423,7 +423,7 @@ DEPENDENCIES
   aws-sdk-s3
   bundler-audit
   capybara (~> 3.40)
-  concurrent-ruby (< 1.3.5)
+  concurrent-ruby (>= 1.3.7)
   dotenv-rails
   fastruby-styleguide!
   font-awesome-rails (>= 4.7.0.9)


### PR DESCRIPTION
## What

Security fix: unpin `concurrent-ruby` (`< 1.3.5`) and update to `>= 1.3.7` (resolves to 1.3.7).

## Why

The `< 1.3.5` ceiling was added in the Rails 6.1 era (commit `76656e2`) to guard the concurrent-ruby 1.3.5 change that dropped its `logger` dependency and broke Rails < 7.1. On **Rails 8.1 that guard is obsolete** — and the ceiling was actively pinning the app to 1.3.4, which carries **CVE-2026-54904 / -54905 / -54906** (fixed in 1.3.7). So the pin was doing net harm: no longer protecting anything, and holding three CVEs open.

## Changes

- `Gemfile`: replaced `gem "concurrent-ruby", "< 1.3.5"` with a documented `>= 1.3.7` **security floor** (comment explains the obsolete guard + the CVEs)
- Both `Gemfile.lock` and the dual-boot `Gemfile.next.lock` updated (1.3.4 → 1.3.7)
- Used `--conservative` so nothing else moved (`rack` stays 2.x)

## Verification (local)

- `bundle-audit`: **concurrent-ruby advisories cleared** (no longer flagged)
- App boots on concurrent-ruby 1.3.7
- Test suite: **16 runs, 52 assertions, 0 failures, 0 errors, 0 skips** — the lifted guard causes no regression on Rails 8.1
- `rubocop` clean (exact CI config), `reek` clean

## Note

This clears the last of the security advisories in the audit except `webrick` (transitive via rackup, no upstream patch yet, low exposure since puma serves production). The puma CVEs are handled in a separate PR.
