### PR TITLE
Remove EOL turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ gem "sass-rails", "~> 6.0"
 gem "font-awesome-rails", ">= 4.7.0.9"
 gem "terser"
 
-gem "turbolinks", "~> 5"
 gem "redcarpet"
 gem "wicked_pdf", "1.4.0"
 gem "wkhtmltopdf-binary", "0.12.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,9 +388,6 @@ GEM
     tilt (2.8.0)
     timeout (0.6.1)
     tsort (0.2.0)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -444,7 +441,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.1.0)
   terser
-  turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
   wicked_pdf (= 1.4.0)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -388,9 +388,6 @@ GEM
     tilt (2.8.0)
     timeout (0.6.1)
     tsort (0.2.0)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -444,7 +441,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.1.0)
   terser
-  turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
   wicked_pdf (= 1.4.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require fastruby/styleguide
 //
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/form.js
+++ b/app/assets/javascripts/form.js
@@ -1,22 +1,11 @@
-// Custom file upload input functionality
-$(document).on('turbolinks:load', function() {
-
-	$('.new_gemfile').on('change', function(e){
-	  var fileName = e.target.value.split( '\\' ).pop();
-	  $('.file-custom').text(fileName);
-	  $('.file-custom').css('color', '#222');
-	  $('.check_button').removeAttr('disabled');
-	  $('.check_button').show();
-	  $('.file-upload').hide();
-	})
-
-	$('.edit_gemfile').on('change', function(e){
-	  var fileName = e.target.value.split( '\\' ).pop();
-	  $('.file-custom').text(fileName);
-	  $('.file-custom').css('color', '#222');
-	  $('.check_button').removeAttr('disabled');
-	  $('.check_button').show();
-	  $('.file-upload').hide();
-	})
-	
-})
+// Custom file upload input functionality.
+// Delegated from `document` so it binds once and keeps working across full
+// page loads regardless of script load order.
+$(document).on('change', '.new_gemfile, .edit_gemfile', function(e) {
+  var fileName = e.target.value.split('\\').pop();
+  $('.file-custom').text(fileName);
+  $('.file-custom').css('color', '#222');
+  $('.check_button').removeAttr('disabled');
+  $('.check_button').show();
+  $('.file-upload').hide();
+});

--- a/app/assets/javascripts/header.js
+++ b/app/assets/javascripts/header.js
@@ -1,41 +1,43 @@
-// All header behaviours
-$(document).on('turbolinks:load', function() {
-  // Navbar toggle button
-  $('.navbar-toggler').click(function(){
-    $(this).toggleClass('open');
-    $('.cta').toggleClass('show');
-    $('header').toggleClass('open');
-  });
+// All header behaviours.
+// Interactive handlers are delegated from `document` so they bind once
+// regardless of script load order; the sticky-on-load state is set on DOM
+// ready (fires on each full page load).
 
-  // Makes navbar sticky on load if scrollTop >= topSectionHeight
+// Navbar toggle button
+$(document).on('click', '.navbar-toggler', function() {
+  $(this).toggleClass('open');
+  $('.cta').toggleClass('show');
+  $('header').toggleClass('open');
+});
+
+// Closes menu on mobile when clicking a menu item
+$(document).on('click', '.navbar-nav a', function() {
+  $('.navbar-toggler').removeClass('open');
+  $('.navbar-collapse').removeClass('in');
+  $('.navbar-toggler').addClass('collapsed');
+});
+
+// Makes navbar sticky on scroll if scrollTop >= topSectionHeight
+$(document).on('scroll', function() {
   var topSectionHeight = $('.top-section').outerHeight() / 2;
   var scrollTop = $(document).scrollTop();
-  if(scrollTop >= topSectionHeight){
+
+  if (scrollTop >= topSectionHeight) {
+    $('header').addClass('fixed');
+  } else if ($('.navbar-collapse').hasClass('in')) {
+    $('header').addClass('fixed');
+  } else {
+    $('header').removeClass('fixed');
+  }
+});
+
+// Makes navbar sticky on load if scrollTop >= topSectionHeight
+function initHeaderStickyState() {
+  var topSectionHeight = $('.top-section').outerHeight() / 2;
+  var scrollTop = $(document).scrollTop();
+  if (scrollTop >= topSectionHeight) {
     $('header').addClass('fixed');
     $('.cta').addClass('show');
   }
-
-  // Makes navbar sticky on scroll if scrollTop >= topSectionHeight
-  $(document).scroll(function(){
-
-    var topSectionHeight = $('.top-section').outerHeight() / 2;
-    var scrollTop = $(document).scrollTop();
-
-    if(scrollTop >= topSectionHeight){
-      $('header').addClass('fixed');
-    }else if($('.navbar-collapse').hasClass('in')){
-      $('header').addClass('fixed');
-    }
-    else{
-      $('header').removeClass('fixed');
-    }
-
-  })
-
-  // Closes menu on mobile when clicking a menu item
-  $('.navbar-nav a').on('click', function() {
-    $('.navbar-toggler').removeClass('open');
-    $('.navbar-collapse').removeClass('in');
-    $('.navbar-toggler').addClass('collapsed');
-  })
-})
+}
+$(initHeaderStickyState);

--- a/app/assets/javascripts/utils.js
+++ b/app/assets/javascripts/utils.js
@@ -1,25 +1,25 @@
-$(document).on('turbolinks:load', function() {
-  // Smooth scroll behaviour
-  $('a.scrollto').on('click', function(event) {
-
-    var hash = this.hash;
-    event.preventDefault();
-    var menuHeight = $('header').outerHeight();
-    $('html, body').animate({
-      scrollTop: $(hash).offset().top - menuHeight
-    }, 800);
-
-  });
-
-  $('.results-content').each(function(e){
-		
-		var advisoryDescriptionHeight = $('.advisory-description', this).outerHeight();
-		var advisoryDescriptionContentHeight = $('.advisory-description .advisory-description-content', this).outerHeight();
-		var collapseButton = $('.btn-readmore', this);
-
-		if(advisoryDescriptionHeight >= advisoryDescriptionContentHeight){
-			collapseButton.hide();
-		}
-  })
-  
+// Smooth scroll behaviour — delegated from `document` so it binds once
+// regardless of script load order.
+$(document).on('click', 'a.scrollto', function(event) {
+  var hash = this.hash;
+  event.preventDefault();
+  var menuHeight = $('header').outerHeight();
+  $('html, body').animate({
+    scrollTop: $(hash).offset().top - menuHeight
+  }, 800);
 });
+
+// Hide the "read more" toggle when an advisory description isn't clipped.
+// Runs on DOM ready (fires on each full page load).
+function initReadMoreToggles() {
+  $('.results-content').each(function() {
+    var advisoryDescriptionHeight = $('.advisory-description', this).outerHeight();
+    var advisoryDescriptionContentHeight = $('.advisory-description .advisory-description-content', this).outerHeight();
+    var collapseButton = $('.btn-readmore', this);
+
+    if (advisoryDescriptionHeight >= advisoryDescriptionContentHeight) {
+      collapseButton.hide();
+    }
+  });
+}
+$(initReadMoreToggles);


### PR DESCRIPTION
## What

Removes the EOL `turbolinks` gem. It is dropped outright, not replaced with a JS framework.

## Why

`turbolinks` has been end-of-life since 2019. This app is a two-page, Sprockets-based form tool with no need for SPA-style navigation, Turbo Frames, or Turbo Streams, so removing it (full page loads) is the right fit.

Adopting `turbo-rails` was attempted first but reverted: turbo-rails 2.x ships **ESM-only** JavaScript (`export {...}`), which cannot be `//= require`d into a Sprockets classic-script bundle — the `export` is a `SyntaxError` that breaks the whole `application.js`. Making Turbo work here would require migrating the asset pipeline to importmap or a JS bundler, which is deliberately out of scope for this cleanup.

## Changes

- `Gemfile`: remove `gem "turbolinks"`
- `application.js`: drop `//= require turbolinks` (nothing replaces it)
- `header.js` / `form.js` / `utils.js`: these handlers were bound inside a `turbolinks:load` callback. Rebind the interactive handlers (file-input change, navbar/menu clicks, smooth-scroll) via **jQuery event delegation on `document`** (bind once, survive full page loads), and run the on-display init (sticky header, read-more visibility) on **DOM ready**. No dependency on any navigation-library load event.
- `Gemfile.lock` + dual-boot `Gemfile.next.lock` updated

## Verification

- Boots; `assets:precompile` clean (no turbolinks/turbo in the bundle)
- Unit tests: **16 runs, 52 assertions, 0 failures**
- `rubocop` clean (exact CI config), `reek` clean
- **System test** (`upload → results → PDF`) passes in a real headless Chrome (run locally against Chrome/chromedriver 150) — this is the check that matters for a navigation change

## Follow-up

A separate PR will convert the app's JavaScript from jQuery to vanilla JS (kept out of this focused change).
