### PR TITLE
Integrate Sentry for exception tracking

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,4 @@ AWS_BUCKET=<insert aws bucket here>
 AWS_ACCESS_KEY_ID=<insert aws access key>
 AWS_SECRET_ACCESS_KEY=<insert aws secret access>
 EXECJS_RUNTIME=Node
+SENTRY_DSN=<insert sentry dsn here>

--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,12 @@ group :development do
   gem "spring-watcher-listen", "~> 2.1.0"
 end
 
+# Exception tracking. Reports unhandled exceptions to Sentry in production;
+# the DSN is supplied via the SENTRY_DSN env var (see .env.sample). sentry-rails
+# auto-installs the Rack/Rails middleware, so no controller changes are needed.
+group :production do
+  gem "sentry-ruby"
+  gem "sentry-rails"
+end
+
 gem "tzinfo-data", platforms: [:windows, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,6 +368,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sentry-rails (6.6.2)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.6.2)
+    sentry-ruby (6.6.2)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     spring (4.7.0)
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
@@ -438,6 +445,8 @@ DEPENDENCIES
   rubocop-rails-omakase
   sass-rails (~> 6.0)
   selenium-webdriver
+  sentry-rails
+  sentry-ruby
   spring
   spring-watcher-listen (~> 2.1.0)
   terser

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -368,6 +368,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sentry-rails (6.6.2)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.6.2)
+    sentry-ruby (6.6.2)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     spring (4.7.0)
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
@@ -438,6 +445,8 @@ DEPENDENCIES
   rubocop-rails-omakase
   sass-rails (~> 6.0)
   selenium-webdriver
+  sentry-rails
+  sentry-ruby
   spring
   spring-watcher-listen (~> 2.1.0)
   terser

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,10 @@
+if Rails.env.production? && ENV["SENTRY_DSN"].present?
+  Sentry.init do |config|
+    config.dsn = ENV["SENTRY_DSN"]
+    config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+
+    # Capture 100% of transactions for performance tracing. Lower this if the
+    # volume becomes noisy or the Sentry quota gets tight.
+    config.traces_sample_rate = 1.0
+  end
+end


### PR DESCRIPTION
### GitHub Issue

Closes #61

### Motivation / Context

Exceptions are currently only written to the production logs. This wires the
app up to Sentry so unhandled exceptions are reported and surfaced for
tracking, mirroring the approach used in fastruby/points#336.

### Changes

- Add `sentry-ruby` + `sentry-rails` (new `:production` group). `sentry-rails`
  auto-installs the Rack/Rails middleware, so no controller changes are needed.
- `config/initializers/sentry.rb`: production-only `Sentry.init`, DSN read from
  `ENV["SENTRY_DSN"]`. Guarded so a missing DSN is a no-op (safe for any
  environment without the var set).
- `.env.sample`: add `SENTRY_DSN` placeholder.
- Update both lockfiles (`Gemfile.lock` and `Gemfile.next.lock`) for the
  dual-boot setup.

`config.send_default_pii` is intentionally left at its default (`false`) so we
don't ship client IPs, headers, or request bodies to a third party, in line
with the app's privacy policy. Stack traces and gem context are enough to
debug.

### QA / Testing Instructions

The `SENTRY_DSN` value needs to be set in the production environment. Once
deployed with a valid DSN, trigger an exception and confirm it shows up in the
Sentry project.

### Screenshots

N/A
