### PR TITLE
Remove unused font-awesome-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem "puma", "~> 8.0"
 gem "minitest", "< 6"
 gem "nokogiri", ">= 1.13.0"
 gem "sass-rails", "~> 6.0"
-gem "font-awesome-rails", ">= 4.7.0.9"
 gem "terser"
 
 gem "redcarpet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,8 +174,6 @@ GEM
     erubi (1.13.1)
     execjs (2.10.1)
     ffi (1.17.4)
-    font-awesome-rails (4.7.0.9)
-      railties (>= 3.2, < 9.0)
     globalid (1.4.0)
       activesupport (>= 6.1)
     i18n (1.15.2)
@@ -430,7 +428,6 @@ DEPENDENCIES
   concurrent-ruby (>= 1.3.7)
   dotenv-rails
   fastruby-styleguide!
-  font-awesome-rails (>= 4.7.0.9)
   kt-paperclip (~> 8.0.0)
   listen (>= 3.5)
   minitest (< 6)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -174,8 +174,6 @@ GEM
     erubi (1.13.1)
     execjs (2.10.1)
     ffi (1.17.4)
-    font-awesome-rails (4.7.0.9)
-      railties (>= 3.2, < 9.0)
     globalid (1.4.0)
       activesupport (>= 6.1)
     i18n (1.15.2)
@@ -430,7 +428,6 @@ DEPENDENCIES
   concurrent-ruby (>= 1.3.7)
   dotenv-rails
   fastruby-styleguide!
-  font-awesome-rails (>= 4.7.0.9)
   kt-paperclip (~> 8.0.0)
   listen (>= 3.5)
   minitest (< 6)

--- a/app/assets/stylesheets/pdf.scss
+++ b/app/assets/stylesheets/pdf.scss
@@ -1,6 +1,3 @@
-// 0-font awesome
-@import "font-awesome";
-
 // 1-styleguide
 @import "fastruby/styleguide";
 


### PR DESCRIPTION
## What

Removes the unused `font-awesome-rails` gem.

## Why

`font-awesome-rails` was pulled in solely by a bare `@import "font-awesome"` in `app/assets/stylesheets/pdf.scss`, but **no icon is ever rendered**: there are no `fa-` classes, no `fa_icon` helpers, and no Font Awesome glyphs anywhere in the views or stylesheets. It imported the entire Font Awesome CSS plus its webfonts (`fontawesome-webfont.woff/ttf/svg`) into the PDF asset bundle for zero visible benefit.

The `fastruby-styleguide` gem does **not** depend on it (the styleguide uses Material Icons + Bootstrap, self-contained). `font-awesome-rails` is a direct-only dependency — nothing pulls it transitively.

## Changes

- `Gemfile`: remove `gem "font-awesome-rails"`
- `pdf.scss`: remove the `@import "font-awesome"` line (and its stale section comment)
- `Gemfile.lock` + dual-boot `Gemfile.next.lock` updated

## Verification

- `assets:precompile` compiles `pdf.css` cleanly and **no `fontawesome-webfont` assets are emitted** anymore
- Unit tests: **16 runs, 52 assertions, 0 failures**
- `rubocop` clean (exact CI config), `reek` clean
- **System test** (upload → results → PDF download) passes in headless Chrome — the PDF still renders correctly
