### PR TITLE
Update wicked_pdf 1.4.0 -> 2.8.2 (hold wkhtmltopdf-binary at 0.12.3.1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,10 @@ gem "sass-rails", "~> 6.0"
 gem "terser"
 
 gem "redcarpet"
-gem "wicked_pdf", "1.4.0"
+gem "wicked_pdf", "~> 2.8"
+# wkhtmltopdf-binary is held at 0.12.3.1: the 0.12.6.x Linux binary segfaults
+# (SIGSEGV) in CI/Heroku, and 0.12.6 also blocks local file access by default,
+# which breaks the PDF's logo/stylesheet. wkhtmltopdf is EOL, so 0.12.3.1 stays.
 gem "wkhtmltopdf-binary", "0.12.3.1"
 
 gem "fastruby-styleguide", git: "https://github.com/fastruby/styleguide.git", branch: "gh-pages"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,8 +407,9 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked_pdf (1.4.0)
+    wicked_pdf (2.8.2)
       activesupport
+      ostruct
     wkhtmltopdf-binary (0.12.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -443,7 +444,7 @@ DEPENDENCIES
   terser
   tzinfo-data
   web-console (>= 3.3.0)
-  wicked_pdf (= 1.4.0)
+  wicked_pdf (~> 2.8)
   wkhtmltopdf-binary (= 0.12.3.1)
 
 RUBY VERSION

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -407,8 +407,9 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked_pdf (1.4.0)
+    wicked_pdf (2.8.2)
       activesupport
+      ostruct
     wkhtmltopdf-binary (0.12.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -443,7 +444,7 @@ DEPENDENCIES
   terser
   tzinfo-data
   web-console (>= 3.3.0)
-  wicked_pdf (= 1.4.0)
+  wicked_pdf (~> 2.8)
   wkhtmltopdf-binary (= 0.12.3.1)
 
 RUBY VERSION


### PR DESCRIPTION
## What

Updates `wicked_pdf` 1.4.0 → 2.8.2. **`wkhtmltopdf-binary` is intentionally held at 0.12.3.1** (not bumped).

## Why

`wicked_pdf` was exact-pinned at 1.4.0 (2019). Bumping the maintained Ruby gem to 2.8.2 is safe: the `render pdf:` call and the `wicked_pdf_stylesheet_link_tag` / `wicked_pdf_image_tag` helpers are unchanged in 2.x, and there's no `wicked_pdf` initializer to migrate.

**Why the binary is held at 0.12.3.1:** I first tried bumping `wkhtmltopdf-binary` to 0.12.6.10, but CI caught two problems that would also hit **production** (same Linux binary on Heroku):
- the 0.12.6.x Linux binary **segfaults (SIGSEGV)** during PDF generation;
- wkhtmltopdf 0.12.6 **blocks local file access by default**, which breaks the PDF's embedded logo/stylesheet.

wkhtmltopdf is EOL (0.12.6 is the last release), so rather than fight an unstable binary, the binary stays at 0.12.3.1 — the exact version production already runs successfully. Only the Ruby gem moves.

## Changes

- `Gemfile`: `wicked_pdf "1.4.0"` → `"~> 2.8"`; `wkhtmltopdf-binary` kept at `"0.12.3.1"` with an explanatory comment
- `--conservative` bundle; `rack` unchanged; both lockfiles updated

## Verification

- PDF controller test (`test_show_with_the_PDF_format_renders_a_PDF_successfully`) — green
- Full suite **16/52/0**, `rubocop` + `reek` clean
- Live server E2E earlier confirmed upload → PDF download returns a valid `%PDF`
- The binary is unchanged from what production already runs, so the SIGSEGV path is avoided
