### PR TITLE
Enable Rails built-in health check endpoint at /up

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
 
+  # Rails' built-in health check endpoint. Returns 200 when the app boots with
+  # no exceptions, 500 otherwise. Responds with an HTML page (browsers/bots) or
+  # a JSON body (Accept: application/json), so uptime monitors, load balancers,
+  # and JSON clients are all covered by the same endpoint.
+  get "up" => "rails/health#show", as: :rails_health_check
+
   get 'home/index'
   get 'home/privacy'
   root :to => "home#index"


### PR DESCRIPTION
## What

Enables Rails' built-in health check endpoint at `/up` by mounting `Rails::HealthController#show`:

```ruby
get "up" => "rails/health#show", as: :rails_health_check
```

No custom controller. This is the framework's own one-size-fits-all health check, introduced in Rails 7.1.

## Why

Uptime monitors, load balancers, and container orchestrators need a stable endpoint to poll. The built-in controller returns `200` when the app boots with no exceptions and `500` otherwise.

## Behavior

The controller responds to all three request styles we need, from a single route:

| Request | Response |
|---|---|
| `Accept: text/html` (browser) | `200`, green HTML page |
| `Accept: application/json` | `200`, `{"status":"up","timestamp":...}` |
| Bot / no `Accept` / `*/*` | `200`, HTML page |

Verified locally against a booted server (all `200`). No `host_authorization` or `allow_browser` guard blocks it, and it runs as a standalone `ActionController::Base`, so `protect_from_forgery` / CSRF does not apply.

## Notes

Per the Rails docs, this endpoint reflects only that the app booted, not the status of downstream dependencies (DB, S3). That is the intended scope of `rails/health#show`; a dependency-aware check would need a custom action, which is deliberately out of scope here.
