### PR TITLE
Update rubocop 1.88.1 -> 1.88.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
-    rubocop (1.88.1)
+    rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -316,7 +316,7 @@ GEM
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
-    rubocop (1.88.1)
+    rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)


### PR DESCRIPTION
## What

Patch bump: `rubocop` 1.88.1 → 1.88.2 (transitive via `rubocop-rails-omakase`).

## Details

- Lockfiles only; `--conservative` bundle; `rack` unchanged.
- Linter-only, dev/test surface.

## Verification

- `rubocop -c ./.rubocop_with_todo.yml .` (exact CI command) → **42 files, 0 offenses** at 1.88.2
- Full suite **16 runs, 52 assertions, 0 failures**
- `reek` clean
