### PR TITLE
Update minitest 5.27.0 -> 6.0.6 (add minitest-mock)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,11 +30,11 @@ gem "ostruct"
 # in 1.3.7.
 gem "concurrent-ruby", ">= 1.3.7"
 gem "puma", "~> 8.0"
-# minitest 6.0 dropped minitest/mock.rb into a separate minitest-mock gem;
-# pinned below 6 so a transitive bump (e.g. via `bundle update rails`)
-# doesn't silently drag the test suite's own framework across a major
-# version as collateral.
-gem "minitest", "< 6"
+# minitest 6.0 moved minitest/mock into a separate minitest-mock gem. The test
+# suite uses it (`require "minitest/mock"` + `.stub`), so it's declared
+# explicitly now that we're on minitest 6.
+gem "minitest"
+gem "minitest-mock"
 gem "nokogiri", ">= 1.13.0"
 gem "sass-rails", "~> 6.0"
 gem "terser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,10 @@ GEM
     mime-types-data (3.2026.0701)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.27.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    minitest-mock (5.27.0)
     net-imap (0.6.4.1)
       date
       net-protocol
@@ -428,7 +431,8 @@ DEPENDENCIES
   fastruby-styleguide!
   kt-paperclip (~> 8.0.0)
   listen (>= 3.5)
-  minitest (< 6)
+  minitest
+  minitest-mock
   next_rails
   nokogiri (>= 1.13.0)
   ostruct

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -223,7 +223,10 @@ GEM
     mime-types-data (3.2026.0701)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (5.27.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    minitest-mock (5.27.0)
     net-imap (0.6.4.1)
       date
       net-protocol
@@ -428,7 +431,8 @@ DEPENDENCIES
   fastruby-styleguide!
   kt-paperclip (~> 8.0.0)
   listen (>= 3.5)
-  minitest (< 6)
+  minitest
+  minitest-mock
   next_rails
   nokogiri (>= 1.13.0)
   ostruct


### PR DESCRIPTION
## What

Updates `minitest` 5.27.0 → 6.0.6, removing the deliberate `< 6` pin, and adds `minitest-mock`.

## Why

The `< 6` pin was intentional: minitest 6.0 **extracted `minitest/mock` into a separate `minitest-mock` gem**, and this suite depends on it — `require "minitest/mock"` and `.stub` in `test/models/gemfile_test.rb` and `test/lib/bundler_audit_database_preparer_test.rb`. Moving to 6.0 therefore requires declaring `minitest-mock` explicitly. This is exactly the split the old pin's comment anticipated; it's now handled rather than avoided.

## Changes

- `Gemfile`: `gem "minitest", "< 6"` → `gem "minitest"` + `gem "minitest-mock"` (comment updated)
- Both `Gemfile.lock` and `Gemfile.next.lock` updated (`--conservative`; `rack` unchanged)

## Verification

- Confirmed minitest 6.0.6 no longer ships `minitest/mock.rb`; `minitest-mock` supplies it
- **Full suite green: 16 runs, 53 assertions, 0 failures, 0 errors** — the `.stub`-based tests pass
- Boots on minitest 6.0.6; `rubocop` clean (exact CI config); `reek` clean
